### PR TITLE
Fix liquid problems

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@ layout: default
     Written on {{ page.date | date: "%B %e, %Y" }}
   </div>
  
-  {{% if page.comments %}}
+  {% if page.comments %}
   {% include disqus.html %}
-  {{% endif %}}
+  {% endif %}
 </article>

--- a/_posts/2022-11-15-json-in-apim-policies.md
+++ b/_posts/2022-11-15-json-in-apim-policies.md
@@ -20,9 +20,11 @@ Suppose I have 2 APIM products defined with the ID's `product-a` and `product-b`
 I then created an APIM policy that would use this named value, like this:
 
 ```json
+{% raw %}
 <set-header name="myheader" exist-action="override">
     <value>{{some-value-@(context.Product.Id)}}</value>
 </set-header>
+{% endraw %}
 ```
 
 And by that, I thought I was done as I would add an additional header to the backend request where the value of that header would be the content of the `named value` that corresponds with the product context.


### PR DESCRIPTION
Fix some liquid syntax errors in the post.html layout

Make sure that a specific code-sample in a blog-post is not parsed by the liquid template to prevent that the code-block is not rendered correctly.